### PR TITLE
Adding check for non dictionary entries

### DIFF
--- a/__main__.py
+++ b/__main__.py
@@ -28,7 +28,6 @@ except IOError:
 
 blocks = yaml.load(source_file, Loader=yaml.FullLoader)
 for x in blocks:
-    # assumption is we only care about things that are dictionary for env variables
     if x.get('op') == 'add' and x.get('path') == '/spec/template/spec/containers/0/env/-':
         name = x['value']['name']
         value = x['value']['value']

--- a/__main__.py
+++ b/__main__.py
@@ -29,7 +29,7 @@ except IOError:
 blocks = yaml.load(source_file, Loader=yaml.FullLoader)
 for x in blocks:
     # assumption is we only care about things that are dictionary for env variables
-    if x.get('op') == 'add' and type(x['value']) is dict:
+    if x.get('op') == 'add' and x.get('path') == '/spec/template/spec/containers/0/env/-':
         name = x['value']['name']
         value = x['value']['value']
 

--- a/__main__.py
+++ b/__main__.py
@@ -28,7 +28,8 @@ except IOError:
 
 blocks = yaml.load(source_file, Loader=yaml.FullLoader)
 for x in blocks:
-    if x.get('op') == 'add':
+    # assumption is we only care about things that are dictionary for env variables
+    if x.get('op') == 'add' and type(x['value']) is dict:
         name = x['value']['name']
         value = x['value']['value']
 


### PR DESCRIPTION
In AMS there is an entry with a int and another with an array of strings, this causes the converter to fail